### PR TITLE
Make this crate `#![no_std]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "https://docs.rs/assume"
 
 repository = "https://github.com/NicholasGorski/assume"
 keywords = ["macro", "assume", "assert"]
-categories = ["rust-patterns"]
+categories = ["rust-patterns", "no-std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Assumes that the given condition is true.
 ///
 /// This macro allows the expression of invariants in code. For example, one might `assume!` that


### PR DESCRIPTION
Makes it possible to use this crate in a `no-std` target.